### PR TITLE
chore: improve accessibility of static indicator

### DIFF
--- a/packages/next/src/client/components/react-dev-overlay/internal/container/StaticIndicator.tsx
+++ b/packages/next/src/client/components/react-dev-overlay/internal/container/StaticIndicator.tsx
@@ -13,6 +13,7 @@ export function StaticIndicator({ dispatcher }: { dispatcher?: Dispatcher }) {
           dispatcher?.onStaticIndicator(false)
         }}
         className="nextjs-toast-hide-button"
+        aria-label="Hide static indicator"
         style={{ marginLeft: 'var(--size-gap)' }}
       >
         <CloseIcon />


### PR DESCRIPTION
# Summary
Add `aria-label` to static indicator button for accessibility

## Description
Some browser reports `Buttons must have discernible text: Element has no title attribute` for the static indicator button.
Then insert `aria-label="Hide static indicator"`

s-ref: [Buttons must have discernible text](https://dequeuniversity.com/rules/axe/4.4/button-name?application=axeAPI)